### PR TITLE
Add more comment on EdgeTPU udev file

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/udev_rules/99-edgetpu-accelerator.rules
+++ b/jsk_fetch_robot/jsk_fetch_startup/udev_rules/99-edgetpu-accelerator.rules
@@ -1,2 +1,8 @@
+# Coral TPU USB changes it's ID during runtime.
+# When we connect the device to the computer. It says
+#   Bus 002 Device 002: ID 1a6e:089a Global Unichip Corp.
+# But after the first run, the device is recognized as following.
+#   Bus 002 Device 003: ID 18d1:9302 Google Inc.
+
 SUBSYSTEM=="usb",ATTRS{idVendor}=="1a6e",GROUP="plugdev"
 SUBSYSTEM=="usb",ATTRS{idVendor}=="18d1",GROUP="plugdev"


### PR DESCRIPTION
please add more comments on all `rules` files. @708yamaguchi 
> jsk_fetch_robot/jsk_fetch_startup/udev_rules/99-insta360-air.rules
do we need this to set permission? 
Does we use `/dev/insta360`  only in kinetic ??
https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_perception/sample/sample_insta360_air.launch#L41
do we need both `# For /dev/video*` and `# For /dev/bus/usb/*` or one used for melodic and one for kinetic?
(and also add newline at the end of file)

> jsk_fetch_robot/jsk_fetch_startup/udev_rules/80-arduino.rules

using `/dev/aruduino` is ROS standard? or do you want this to be JSK standard?

